### PR TITLE
Fix crush on windows which occurs  when bvh data reached to the end.

### DIFF
--- a/ofxBvh/src/ofxBvh.cpp
+++ b/ofxBvh/src/ofxBvh.cpp
@@ -143,9 +143,7 @@ void ofxBvh::update()
 		{
 			need_update = true;
 			
-			currentFrame = frames[index];
-			
-			if (index >= frames.size())
+            if (index >= frames.size())
 			{
 				if (loop)
 					play_head = 0;
@@ -155,6 +153,10 @@ void ofxBvh::update()
 			
 			if (play_head < 0)
 				play_head = 0;
+            
+            index = getFrame();
+            currentFrame = frames[index];
+
 		}
 	}
 	


### PR DESCRIPTION
Hi, dear perfume-dev team.

On Windows with Visual Studio 2012/2013,  app crushes when the BVH data reached to the end.
It came from the ofxBvh.cpp, accessing the wrong index of the frames vector. I fixed it.

Best,
